### PR TITLE
docs: add contributing guidelines with Conventional Commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thanks for considering a contribution to jadibot.
+
+## Commit messages
+
+- Write concise, imperative commit messages.
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Prefix messages with types such as `feat`, `fix`, or `docs`.
+
+Example: `feat: add random post command`.


### PR DESCRIPTION
## Summary
- document commit message expectations
- note adoption of Conventional Commits

## Testing
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68ad4dbbce2c8320a80425f6f2d5d51c